### PR TITLE
Update property names

### DIFF
--- a/src/features/catalogs/CatalogDetail.jsx
+++ b/src/features/catalogs/CatalogDetail.jsx
@@ -48,7 +48,7 @@ export default function CatalogDetails() {
       <section className="p-3">
         <Container size="lg">
           <h2>Courses</h2>
-          <OfferingList catalog={catalog.uuid} admin />
+          <OfferingList cohort={catalog.uuid} admin />
 
           <Button onClick={openAddCourse}>Add course</Button>
         </Container>
@@ -65,7 +65,7 @@ export default function CatalogDetails() {
         <Container size="lg">
           <h2>Members</h2>
 
-          <MemberList catalog={catalog.uuid} />
+          <MemberList cohort={catalog.uuid} />
 
           <Button onClick={openAddMember} className="mt-3">Add member</Button>
         </Container>

--- a/src/features/catalogs/CatalogListItem.jsx
+++ b/src/features/catalogs/CatalogListItem.jsx
@@ -46,8 +46,8 @@ export default function CatalogListItem({ uuid }) {
         <Card.Section>
           <h3>{catalog.name}</h3>
           <p>
-            <CatalogOfferingCount catalog={catalog.uuid} />{' '}
-            <CatalogMemberCount catalog={catalog.uuid} />
+            <CatalogOfferingCount cohort={catalog.uuid} />{' '}
+            <CatalogMemberCount cohort={catalog.uuid} />
           </p>
         </Card.Section>
         <Card.Footer className="justify-content-end w-auto">

--- a/src/features/members/AddMemberModal.jsx
+++ b/src/features/members/AddMemberModal.jsx
@@ -11,7 +11,7 @@ export default function AddMemberModal({ isOpen, onClose, catalog }) {
   const dispatch = useDispatch();
   const [allMembers] = useMembers();
   const catalogMemberEmails = allMembers
-    .filter(member => member.catalog === catalog)
+    .filter(member => member.cohort === catalog)
     .map(member => member.email);
 
   const [email, setEmail] = useState('');

--- a/src/features/members/CatalogMemberCount.jsx
+++ b/src/features/members/CatalogMemberCount.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import useMembers from './useMembers';
 
-export default function CatalogMemberCount({ catalog }) {
+export default function CatalogMemberCount({ cohort }) {
   const [members] = useMembers();
-  const count = members.filter(member => member.catalog === catalog).length;
+  const count = members.filter(member => member.cohort === cohort).length;
   return <span>{count} member{count === 1 ? '' : 's'}.</span>;
 }
 
 CatalogMemberCount.propTypes = {
-  catalog: PropTypes.string.isRequired,
+  cohort: PropTypes.string.isRequired,
 };

--- a/src/features/members/MemberList.jsx
+++ b/src/features/members/MemberList.jsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import { DataTable, DropdownFilter, TextFilter } from '@edx/paragon';
 import useMembers from './useMembers';
 
-export default function MemberList({ catalog }) {
+export default function MemberList({ cohort }) {
   const [allMembers] = useMembers();
-  const catalogMembers = allMembers.filter(member => member.catalog === catalog);
+  const catalogMembers = allMembers.filter(member => member.cohort === cohort);
 
   if (!catalogMembers.length) {
-    return <p>No members have been invited to this catalog.</p>;
+    return <p>No members have been invited to this cohort.</p>;
   }
 
   const memberData = catalogMembers.map(member => ({
@@ -49,5 +49,5 @@ export default function MemberList({ catalog }) {
 }
 
 MemberList.propTypes = {
-  catalog: PropTypes.string.isRequired,
+  cohort: PropTypes.string.isRequired,
 };

--- a/src/features/offerings/AddOfferingModal.jsx
+++ b/src/features/offerings/AddOfferingModal.jsx
@@ -13,7 +13,7 @@ export default function AddOfferingModal({
   const dispatch = useDispatch();
   const [offerings] = useOfferings();
   const catalogOfferings = offerings
-    .filter((offering) => offering.catalog === catalog)
+    .filter((offering) => offering.cohort === catalog)
     .map((offering) => offering.offering);
   const availableOfferings = partnerOfferings.filter(
     (offering) => !catalogOfferings.includes(offering.id),

--- a/src/features/offerings/CatalogOfferingCount.jsx
+++ b/src/features/offerings/CatalogOfferingCount.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import useOfferings from './useOfferings';
 
-export default function CatalogOfferingCount({ catalog }) {
+export default function CatalogOfferingCount({ cohort }) {
   const [offerings] = useOfferings();
-  const count = offerings.filter(offering => offering.catalog === catalog).length;
+  const count = offerings.filter(offering => offering.cohort === cohort).length;
   return <span>{count} course offering{count === 1 ? '' : 's'}.</span>;
 }
 
 CatalogOfferingCount.propTypes = {
-  catalog: PropTypes.string.isRequired,
+  cohort: PropTypes.string.isRequired,
 };

--- a/src/features/offerings/OfferingList.jsx
+++ b/src/features/offerings/OfferingList.jsx
@@ -4,14 +4,14 @@ import { CardGrid } from '@edx/paragon';
 import AdminOfferingCard from './AdminOfferingCard';
 import useOfferings from './useOfferings';
 
-export default function OfferingList({ catalog }) {
+export default function OfferingList({ cohort }) {
   const [offerings] = useOfferings();
-  const offeringCards = offerings.filter(offering => offering.catalog === catalog).map(
+  const offeringCards = offerings.filter(offering => offering.cohort === cohort).map(
     offering => <AdminOfferingCard key={offering.id} offeringId={offering.id} />,
   );
 
   if (!offeringCards.length) {
-    return <p>No courses have been added to this catalog.</p>;
+    return <p>No courses have been added to this cohort.</p>;
   }
 
   return (
@@ -22,5 +22,5 @@ export default function OfferingList({ catalog }) {
 }
 
 OfferingList.propTypes = {
-  catalog: PropTypes.string.isRequired,
+  cohort: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
API responses now use "cohort" in place of "catalog." This applies a minimal set of updates to maintain functionality.