### PR TITLE
Show all invited users in Insights -> User Details list

### DIFF
--- a/src/features/enrollments/MemberEnrollmentList.jsx
+++ b/src/features/enrollments/MemberEnrollmentList.jsx
@@ -24,7 +24,7 @@ export default function MemberEnrollmentList({ offerings }) {
   );
 
   const { entities } = useContext(EntityContext);
-  const members = uniqBy(entities, 'user');
+  const members = uniqBy(entities, 'email');
   const data = members.map(member => ({
     name: member.name,
     email: member.email,


### PR DESCRIPTION
The list of members was forcing uniqueness on `user`, which doesn't exist for users who have only been invited but don't yet have an associated user.

This change forces uniqueness on email, so now all user-less members are displayed:

<img width="1140" alt="Screenshot 2023-10-18 at 10 34 45 AM" src="https://github.com/academic-innovation/frontend-app-mogc-partners/assets/131684733/ced58db3-9b7a-4d41-9537-8e5c8fd05b50">