### PR TITLE
Hide Available Courses if student is enrolled in all available

### DIFF
--- a/src/features/offerings/EnrolledOfferingList.jsx
+++ b/src/features/offerings/EnrolledOfferingList.jsx
@@ -21,12 +21,16 @@ export default function EnrolledOfferingList({ partnerSlug }) {
     offering => offering.partner === partnerSlug && offering.isEnrolled,
   );
 
+  const Header = () => <h2>Keep Learning</h2>;
   if (!partnerOfferings.length) {
     return (
-      <p>
-        You are not currently enrolled in any {' '}
-        <PartnerName slug={partnerSlug} /> offerings.
-      </p>
+      <>
+        <Header />
+        <p>
+          You are not currently enrolled in any {' '}
+          <PartnerName slug={partnerSlug} /> offerings.
+        </p>
+      </>
     );
   }
 
@@ -34,7 +38,12 @@ export default function EnrolledOfferingList({ partnerSlug }) {
     offering => <EnrolledOfferingCard offeringId={offering.id} />,
   );
 
-  return <Stack gap={3}>{offeringCards}</Stack>;
+  return (
+    <>
+      <Header />
+      <Stack gap={3}>{offeringCards}</Stack>
+    </>
+  );
 }
 
 EnrolledOfferingList.propTypes = {

--- a/src/features/offerings/PartnerOfferingList.jsx
+++ b/src/features/offerings/PartnerOfferingList.jsx
@@ -27,20 +27,25 @@ export default function PartnerOfferingList({ partnerSlug }) {
   }
 
   const partnerOfferings = uniqOfferings.filter(
-    offering => offering.partner === partnerSlug && !offering.isEnrolled,
+    offering => offering.partner === partnerSlug,
+  );
+  const availableOfferings = partnerOfferings.filter(
+    offering => !offering.isEnrolled,
   );
 
-  if (!partnerOfferings.length) {
+  if (!partnerOfferings.length || !availableOfferings.length) {
+    const descriptor = !partnerOfferings.length
+      ? 'is not yet offering any courses.'
+      : 'has no other courses available.';
     return (
       <p>
-        <PartnerName slug={partnerSlug} /> {' '}
-        is not yet offering any courses.
+        <PartnerName slug={partnerSlug} /> {` ${descriptor}`}
       </p>
     );
   }
 
-  const offeringCards = partnerOfferings.map(
-    offering => <OfferingCard offeringId={offering.id} />,
+  const offeringCards = availableOfferings.map(
+    offering => <OfferingCard offeringId={offering.id} key={offering.id} />,
   );
 
   return <CardGrid>{offeringCards}</CardGrid>;

--- a/src/features/offerings/PartnerOfferingList.jsx
+++ b/src/features/offerings/PartnerOfferingList.jsx
@@ -33,22 +33,30 @@ export default function PartnerOfferingList({ partnerSlug }) {
     offering => !offering.isEnrolled,
   );
 
-  if (!partnerOfferings.length || !availableOfferings.length) {
-    const descriptor = !partnerOfferings.length
-      ? 'is not yet offering any courses.'
-      : 'has no other courses available.';
+  const Header = () => <h2>Available Courses</h2>;
+  if (!partnerOfferings.length) {
     return (
-      <p>
-        <PartnerName slug={partnerSlug} /> {` ${descriptor}`}
-      </p>
+      <>
+        <Header />
+        <p>
+          <PartnerName slug={partnerSlug} /> {' is not yet offering any courses.'}
+        </p>
+      </>
     );
+  }
+  if (!availableOfferings.length) {
+    return null;
   }
 
   const offeringCards = availableOfferings.map(
     offering => <OfferingCard offeringId={offering.id} key={offering.id} />,
   );
-
-  return <CardGrid>{offeringCards}</CardGrid>;
+  return (
+    <>
+      <Header />
+      <CardGrid>{offeringCards}</CardGrid>
+    </>
+  );
 }
 
 PartnerOfferingList.propTypes = {

--- a/src/features/partners/PartnerDetails.jsx
+++ b/src/features/partners/PartnerDetails.jsx
@@ -52,7 +52,7 @@ export default function PartnerDetails() {
       {partner && (
         <section className="p-3 pb-5">
           <Container size="lg">
-            <PartnerOfferingList partnerSlug={partner?.slug} />
+            <PartnerOfferingList partnerSlug={partner.slug} />
           </Container>
         </section>
       )}

--- a/src/features/partners/PartnerDetails.jsx
+++ b/src/features/partners/PartnerDetails.jsx
@@ -45,17 +45,17 @@ export default function PartnerDetails() {
             ]}
             activeLabel={partner?.name}
           />
-          <h2>Keep Learning</h2>
           <EnrolledOfferingList partnerSlug={partner?.slug} />
         </Container>
       </section>
 
-      <section className="p-3 pb-5">
-        <Container size="lg">
-          <h2>Available Courses</h2>
-          <PartnerOfferingList partnerSlug={partner?.slug} />
-        </Container>
-      </section>
+      {partner && (
+        <section className="p-3 pb-5">
+          <Container size="lg">
+            <PartnerOfferingList partnerSlug={partner?.slug} />
+          </Container>
+        </section>
+      )}
     </>
   );
 }


### PR DESCRIPTION
### Fixes https://github.com/academic-innovation/frontend-app-mogc-partners/issues/45

If a user was enrolled in all available partner offerings, we would say "_partner name_ is not yet offering any courses" which was inaccurate. With this, we'll hide the Available Courses section if they are already enrolled in all that are available:

<img width="1160" alt="Screenshot 2023-10-18 at 4 39 38 PM" src="https://github.com/academic-innovation/frontend-app-mogc-partners/assets/131684733/e03670b7-bf6f-4914-836f-04c264c4b593">


This also fixes an issue with awkward text if the user was not part of an organization:

**Before**
<img width="993" alt="Screenshot 2023-10-18 at 3 59 24 PM" src="https://github.com/academic-innovation/frontend-app-mogc-partners/assets/131684733/db0c7245-e27e-4e1c-b01e-32f30c338666">

**After**
<img width="1164" alt="Screenshot 2023-10-18 at 4 49 33 PM" src="https://github.com/academic-innovation/frontend-app-mogc-partners/assets/131684733/4e542c68-169e-4a15-bc70-f4535af7e0c8">