### PR TITLE
Fix partnerless redirect

### DIFF
--- a/src/features/partners/PartnerList.jsx
+++ b/src/features/partners/PartnerList.jsx
@@ -15,9 +15,8 @@ export default function PartnerList() {
       dispatch(fetchPartners());
     }
   }, [partnersStatus, dispatch]);
-
   if (partnersStatus === 'fufilled' && partners.length === 0) {
-    return <Redirect to={config.LMS_BASE_URL} />;
+    window.location = config.LMS_BASE_URL;
   }
 
   if (partnersStatus === 'fufilled' && partners.length === 1) {

--- a/src/features/partners/PartnerList.jsx
+++ b/src/features/partners/PartnerList.jsx
@@ -17,6 +17,7 @@ export default function PartnerList() {
   }, [partnersStatus, dispatch]);
   if (partnersStatus === 'fufilled' && partners.length === 0) {
     window.location = config.LMS_BASE_URL;
+    return null;
   }
 
   if (partnersStatus === 'fufilled' && partners.length === 1) {

--- a/src/features/partners/PartnerList.jsx
+++ b/src/features/partners/PartnerList.jsx
@@ -15,6 +15,7 @@ export default function PartnerList() {
       dispatch(fetchPartners());
     }
   }, [partnersStatus, dispatch]);
+
   if (partnersStatus === 'fufilled' && partners.length === 0) {
     window.location = config.LMS_BASE_URL;
     return null;


### PR DESCRIPTION
### Fixes https://github.com/academic-innovation/frontend-app-mogc-partners/issues/44

`config.LMS_BASE_URL` is an absolute URL, so this PR changes the redirect to set `window.location` to the base URL when the user is not assigned to an organization.

https://github.com/academic-innovation/frontend-app-mogc-partners/assets/131684733/8bd92216-6b74-49fc-a4d9-c4ccc25cf9d6

