### PR TITLE
Redirect managers to admin from /partnerSlug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ temp/babel-plugin-react-intl
 # This file is included as a part of tutor-mfe
 # https://github.com/overhangio/tutor-mfe/blob/master/tutormfe/templates/mfe/apps/mfe/webpack.dev.config.js
 webpack.dev.config.js
+webpack.dev-tutor.config.js

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run lint

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "fedx-scripts webpack",
+    "prepare": "husky install",
     "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
     "is-es5": "es-check es5 ./dist/*.js",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
@@ -19,11 +20,6 @@
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
     "test": "fedx-scripts jest --coverage --passWithNoTests"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run lint"
-    }
   },
   "author": "edX",
   "license": "AGPL-3.0",

--- a/src/features/partners/ManagementMenu.jsx
+++ b/src/features/partners/ManagementMenu.jsx
@@ -13,7 +13,7 @@ export default function ManagementMenu({ partner }) {
     <DropdownButton variant="inverse-outline-primary" id="management-menu" title="Manage">
       <MenuLink to={`/${partner}/admin`}>Cohorts</MenuLink>
       <MenuLink to={`/${partner}/admin/insights`}>Insights</MenuLink>
-      <MenuLink to={`/${partner}`}>Learner view</MenuLink>
+      <MenuLink to={`/${partner}/details`}>Learner view</MenuLink>
     </DropdownButton>
   );
 }

--- a/src/features/partners/PartnerAdmin.jsx
+++ b/src/features/partners/PartnerAdmin.jsx
@@ -57,7 +57,7 @@ export default function PartnerDetails() {
           <ResponsiveBreadcrumb
             links={[
               { label: 'Partners', url: '' },
-              { label: partner?.name, url: `/${partnerSlug}` },
+              { label: partner?.name, url: `/${partnerSlug}/details` },
             ]}
             activeLabel="Cohort"
           />

--- a/src/features/partners/PartnerDetails.jsx
+++ b/src/features/partners/PartnerDetails.jsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router';
+import { Redirect } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { Container, Stack } from '@edx/paragon';
 
 import { fetchPartners, selectPartnerById } from './partnersSlice';
-import ManagementMenu from './ManagementMenu';
 
 import ResponsiveBreadcrumb from '../../common/ResponsiveBreadcrumb';
 import PartnerOfferingList from '../offerings/PartnerOfferingList';
@@ -22,17 +22,16 @@ export default function PartnerDetails() {
     }
   }, [partnersStatus, dispatch]);
 
+  if (partner?.isManager) {
+    return <Redirect to={`${partner.slug}/admin`} />;
+  }
+
   return (
     <>
       <section className="px-3 py-5 bg-primary">
         <Container size="lg">
           <Stack direction="horizontal" gap={3} className="justify-content-between">
             <h1 className="text-white">{partner?.name}</h1>
-            {
-              partner?.isManager
-                ? <ManagementMenu partner={partnerSlug} />
-                : null
-            }
           </Stack>
         </Container>
       </section>

--- a/src/features/partners/PartnerDetails.jsx
+++ b/src/features/partners/PartnerDetails.jsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router';
-import { Redirect } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { Container, Stack } from '@edx/paragon';
 
 import { fetchPartners, selectPartnerById } from './partnersSlice';
+import ManagementMenu from './ManagementMenu';
 
 import ResponsiveBreadcrumb from '../../common/ResponsiveBreadcrumb';
 import PartnerOfferingList from '../offerings/PartnerOfferingList';
@@ -22,16 +22,17 @@ export default function PartnerDetails() {
     }
   }, [partnersStatus, dispatch]);
 
-  if (partner?.isManager) {
-    return <Redirect to={`${partner.slug}/admin`} />;
-  }
-
   return (
     <>
       <section className="px-3 py-5 bg-primary">
         <Container size="lg">
           <Stack direction="horizontal" gap={3} className="justify-content-between">
             <h1 className="text-white">{partner?.name}</h1>
+            {
+              partner?.isManager
+                ? <ManagementMenu partner={partnerSlug} />
+                : null
+            }
           </Stack>
         </Container>
       </section>

--- a/src/features/partners/PartnerRedirect.jsx
+++ b/src/features/partners/PartnerRedirect.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router';
+import { Redirect } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { fetchPartners, selectPartnerById } from './partnersSlice';
+
+export default function PartnerRedirect() {
+  const dispatch = useDispatch();
+  const { partnerSlug } = useParams();
+  const partnersStatus = useSelector((state) => state.partners.status);
+  const partner = useSelector((state) => selectPartnerById(state, partnerSlug));
+
+  useEffect(() => {
+    if (partnersStatus === 'idle') {
+      dispatch(fetchPartners());
+    }
+  }, [partnersStatus, dispatch]);
+
+  if (!partner) {
+    return null;
+  }
+
+  return partner.isManager
+    ? <Redirect to={`${partnerSlug}/admin`} />
+    : <Redirect to={`${partnerSlug}/details`} />;
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -15,6 +15,7 @@ import { Route, Switch } from 'react-router';
 import store from './common/store';
 import appMessages from './i18n';
 import PartnerList from './features/partners/PartnerList';
+import PartnerRedirect from './features/partners/PartnerRedirect';
 import PartnerAdmin from './features/partners/PartnerAdmin';
 import PartnerDetails from './features/partners/PartnerDetails';
 import PartnerStats from './features/partners/PartnerStats';
@@ -29,7 +30,8 @@ subscribe(APP_READY, () => {
       <main id="main">
         <Switch>
           <Route exact path="/" component={PartnerList} />
-          <Route exact path="/:partnerSlug" component={PartnerDetails} />
+          <Route exact path="/:partnerSlug" component={PartnerRedirect} />
+          <Route exact path="/:partnerSlug/details" component={PartnerDetails} />
           <Route exact path="/:partnerSlug/admin" component={PartnerAdmin} />
           <Route exact path="/:partnerSlug/admin/insights" component={PartnerStats} />
           <Route


### PR DESCRIPTION
## Fixes https://github.com/academic-innovation/frontend-app-mogc-partners/issues/55

If a user is a partner manager, redirect them to `/partnerSlug/admin` from `/partnerSlug`.

### Additional changes:
- Fix Husky setup and commit pre-commit hook
- Add `webpack.dev-tutor.config.js` to `.gitignore`