### PR TITLE
Add Learners & Courses to Insights tables

### DIFF
--- a/src/features/enrollments/CourseEnrollmentList.jsx
+++ b/src/features/enrollments/CourseEnrollmentList.jsx
@@ -40,20 +40,18 @@ export default function CourseEnrollmentList({ offerings, cohorts }) {
     return offeringsCourseMap;
   }, {});
 
-  const data = Object.keys(offeringsMap).map(
-    offeringCourseKey => {
-      const offeringData = offeringsMap[offeringCourseKey];
-      return {
-        ...offeringData,
-        learners: new Set(members.reduce((courseLearners, member) => {
-          if (offeringData.cohorts.includes(member.cohort)) {
-            courseLearners.push(member.email);
-          }
-          return courseLearners;
-        }, [])).size,
-      };
-    },
-  );
+  const data = Object.keys(offeringsMap).map(offeringCourseKey => {
+    const offeringData = offeringsMap[offeringCourseKey];
+    return {
+      ...offeringData,
+      learners: new Set(members.reduce((courseLearners, member) => {
+        if (offeringData.cohorts.includes(member.cohort)) {
+          courseLearners.push(member.email);
+        }
+        return courseLearners;
+      }, [])).size,
+    };
+  });
 
   const cohortFilterOptions = getCohortFilterOptions(cohorts);
 

--- a/src/features/enrollments/MemberEnrollmentList.jsx
+++ b/src/features/enrollments/MemberEnrollmentList.jsx
@@ -44,11 +44,11 @@ export default function MemberEnrollmentList({ offerings, cohorts }) {
   }, {});
 
   const { entities } = useContext(EntityContext);
-  const members = entities.reduce((membersMap, member) => {
-    if (Object.keys(membersMap).includes(member.email)) {
-      membersMap[member.email].cohorts.push(member.cohort);
+  const membersMap = entities.reduce((members, member) => {
+    if (Object.keys(members).includes(member.email)) {
+      members[member.email].cohorts.push(member.cohort);
     } else {
-      membersMap[member.email] = {
+      members[member.email] = {
         name: member.name,
         email: member.email,
         cohorts: [member.cohort],
@@ -56,11 +56,11 @@ export default function MemberEnrollmentList({ offerings, cohorts }) {
         completions: offeringEnrollments.filter(memberCompletions(member.user)).length,
       };
     }
-    return membersMap;
+    return members;
   }, {});
 
-  const data = Object.keys(members).map(memberEmail => {
-    const memberData = members[memberEmail];
+  const data = Object.keys(membersMap).map(memberEmail => {
+    const memberData = membersMap[memberEmail];
     return {
       ...memberData,
       offerings: availableOfferings(


### PR DESCRIPTION
### Fixes https://github.com/academic-innovation/frontend-app-mogc-partners/issues/60 & https://github.com/academic-innovation/frontend-app-mogc-partners/issues/61

Adds Learners column to Courses table (total number of learners who are eligible to enroll in a course):

<img width="1107" alt="Screenshot 2023-12-13 at 4 37 08 PM" src="https://github.com/academic-innovation/frontend-app-mogc-partners/assets/131684733/124f2dbf-5700-46ac-985c-3ea01e90df67">

Adds Courses column to Learners table (total number of courses available to all cohorts a user is in):

<img width="1096" alt="Screenshot 2023-12-13 at 4 37 47 PM" src="https://github.com/academic-innovation/frontend-app-mogc-partners/assets/131684733/a01b3055-fc34-404c-861a-7dc7d5dad02c">

-----

**Note:** depends on https://github.com/academic-innovation/frontend-app-mogc-partners/pull/72
