### PR TITLE
Preview As Learner

### DIFF
--- a/src/common/AlertBanner.jsx
+++ b/src/common/AlertBanner.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { PageBanner } from '@openedx/paragon';
+
+export default function AlertBanner({ children, ...props }) {
+  return <PageBanner {...props}>{children}</PageBanner>;
+}
+
+AlertBanner.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+};

--- a/src/common/RouteContext.jsx
+++ b/src/common/RouteContext.jsx
@@ -17,7 +17,6 @@ const initialState = {
 export function RouteProvider({ children }) {
   const [sharedState, setSharedState] = useState(initialState);
 
-  // The value that will be accessible to any descendants of this provider
   const value = useMemo(() => ({ sharedState, setSharedState }), [sharedState]);
 
   return (

--- a/src/common/RouteContext.jsx
+++ b/src/common/RouteContext.jsx
@@ -1,0 +1,33 @@
+import React, {
+  createContext, useState, useContext, useMemo,
+} from 'react';
+import PropTypes from 'prop-types';
+
+const RouteContext = createContext();
+
+export function useRouteContext() {
+  return useContext(RouteContext);
+}
+
+const initialState = {
+  // Determines if partner manager is in Learner Preview
+  isPreview: false,
+};
+
+export function RouteProvider({ children }) {
+  const [sharedState, setSharedState] = useState(initialState);
+
+  // The value that will be accessible to any descendants of this provider
+  const value = useMemo(() => ({ sharedState, setSharedState }), [sharedState]);
+
+  return (
+    <RouteContext.Provider value={value}>{children}</RouteContext.Provider>
+  );
+}
+
+RouteProvider.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+};

--- a/src/features/partners/ManagementToolbar.jsx
+++ b/src/features/partners/ManagementToolbar.jsx
@@ -3,7 +3,13 @@ import PropTypes from 'prop-types';
 import ButtonLink from '../../common/ButtonLink';
 import ButtonLinkGroup from '../../common/ButtonLinkGroup';
 
+import { useRouteContext } from '../../common/RouteContext';
+
 export default function ManagementToolbar({ partner, selected }) {
+  const { sharedState, setSharedState } = useRouteContext();
+
+  const togglePreview = () => setSharedState({ isPreview: !sharedState.isPreview });
+
   const options = ['insights', 'cohorts'];
   const selectedOpt = selected === null ? false : options[Number(selected)];
   const cohortClass = `btn btn-${selectedOpt === options[1] ? 'dark' : 'outline-dark'}`;
@@ -21,7 +27,7 @@ export default function ManagementToolbar({ partner, selected }) {
         </ButtonLinkGroup>
       </div>
       <div className="col col-3">
-        <ButtonLink className="btn btn-primary" link={`/${partner}/details`}>
+        <ButtonLink className="btn btn-primary" link={`/${partner}/details`} onClick={togglePreview}>
           Preview As Learner
         </ButtonLink>
       </div>

--- a/src/features/partners/PartnerDetails.jsx
+++ b/src/features/partners/PartnerDetails.jsx
@@ -8,8 +8,16 @@ import PartnerOfferingList from '../offerings/PartnerOfferingList';
 import EnrolledOfferingList from '../offerings/EnrolledOfferingList';
 import ManagementToolbar from './ManagementToolbar';
 import PartnerHeading from './PartnerHeading';
+import AlertBanner from '../../common/AlertBanner';
+
+import { useRouteContext } from '../../common/RouteContext';
 
 export default function PartnerDetails() {
+  const { sharedState, setSharedState } = useRouteContext();
+  const { isPreview } = sharedState;
+
+  const togglePreview = () => setSharedState({ isPreview: !sharedState.isPreview });
+
   const [partner, partnerSlug] = usePartner();
 
   if (!partner) {
@@ -18,11 +26,22 @@ export default function PartnerDetails() {
 
   return (
     <>
+      {isPreview && (
+        <AlertBanner
+          variant="accentB"
+          dismissible
+          onDismiss={togglePreview}
+        >
+          You are viewing this page as a learner.
+        </AlertBanner>
+      )}
       <PartnerHeading partnerName={partner?.name} />
 
       <section className="p-3 pt-5">
         <Container size="lg">
-          {partner?.isManager && <ManagementToolbar partner={partnerSlug} />}
+          {(partner?.isManager && !isPreview) && (
+            <ManagementToolbar partner={partnerSlug} />
+          )}
           <ResponsiveBreadcrumb
             links={[
               { label: 'Partners', url: '/' },

--- a/src/features/partners/PartnerRedirect.jsx
+++ b/src/features/partners/PartnerRedirect.jsx
@@ -1,15 +1,20 @@
 import { Navigate } from 'react-router-dom';
 
+import { useRouteContext } from '../../common/RouteContext';
+
 import usePartner from './usePartner';
 
 export default function PartnerRedirect() {
+  const { sharedState } = useRouteContext();
+  const { isPreview } = sharedState;
+
   const [partner, partnerSlug] = usePartner();
 
   if (!partner) {
     return null;
   }
 
-  return partner.isManager
+  return (partner.isManager && !isPreview)
     ? <Navigate to={`/${partnerSlug}/admin`} />
     : <Navigate to={`/${partnerSlug}/details`} />;
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -22,6 +22,8 @@ import PartnerDetails from './features/partners/PartnerDetails';
 import PartnerStats from './features/partners/PartnerStats';
 import CohortDetails from './features/cohorts/CohortDetail';
 
+import { RouteProvider } from './common/RouteContext';
+
 import './index.scss';
 
 subscribe(APP_READY, () => {
@@ -35,18 +37,20 @@ subscribe(APP_READY, () => {
       </Helmet>
       <Header />
       <main id="main">
-        <Routes>
-          <Route exact path="/" Component={PartnerList} />
-          <Route exact path="/:partnerSlug" Component={PartnerRedirect} />
-          <Route exact path="/:partnerSlug/details" Component={PartnerDetails} />
-          <Route exact path="/:partnerSlug/admin" Component={PartnerAdmin} />
-          <Route exact path="/:partnerSlug/admin/insights" Component={PartnerStats} />
-          <Route
-            exact
-            path="/:partnerSlug/admin/catalog/:cohortUuid"
-            Component={CohortDetails}
-          />
-        </Routes>
+        <RouteProvider>
+          <Routes>
+            <Route exact path="/" Component={PartnerList} />
+            <Route exact path="/:partnerSlug" Component={PartnerRedirect} />
+            <Route exact path="/:partnerSlug/details" Component={PartnerDetails} />
+            <Route exact path="/:partnerSlug/admin" Component={PartnerAdmin} />
+            <Route exact path="/:partnerSlug/admin/insights" Component={PartnerStats} />
+            <Route
+              exact
+              path="/:partnerSlug/admin/catalog/:cohortUuid"
+              Component={CohortDetails}
+            />
+          </Routes>
+        </RouteProvider>
       </main>
       <Footer />
     </AppProvider>,


### PR DESCRIPTION
Updates Preview As Learner mode to provide UI context:

https://github.com/academic-innovation/frontend-app-mogc-partners/assets/131684733/3ac99453-9b4a-46b9-86f1-29beaf789fa0

- Add `RouteContext` to enable passing props to routes
- Add `AlertBanner` component for displaying Paragon `PageBanner` component
- Update `PartnerDetails` to show `AlertBanner` and hide `ManagementToolbar` if in learner preview
- Update `PartnerRedirect` to forward to Details page if in learner preview