### PR TITLE
Include courses with no enrollments in PartnerStats

### DIFF
--- a/src/features/partners/PartnerStats.jsx
+++ b/src/features/partners/PartnerStats.jsx
@@ -14,12 +14,12 @@ import StatCard from './StatCard';
 import ManagementToolbar from './ManagementToolbar';
 import PartnerHeading from './PartnerHeading';
 import { selectCohortsByPartnerSlug } from '../cohorts/cohortsSlice';
-import { selectEnrolledOfferingsByPartnerSlug } from '../offerings/offeringsSlice';
+import { selectOfferingsByPartnerSlug } from '../offerings/offeringsSlice';
 
 export default function PartnerStats() {
   const [partner, partnerSlug] = usePartner();
   const [partnerOfferings] = useOfferings(
-    state => selectEnrolledOfferingsByPartnerSlug(state, partnerSlug),
+    state => selectOfferingsByPartnerSlug(state, partnerSlug),
   );
   const [partnerCohorts] = useCohorts(
     state => selectCohortsByPartnerSlug(state, partnerSlug),


### PR DESCRIPTION
Fixes https://trello.com/c/RkGd054T/579-molp-partner-admin-im-seeing-at-least-one-instance-of-a-cohort-offering-thats-not-showing-up-under-course-details-in-the-partner

`PartnerStats` was filtering courses for those that had at least one enrollment. This has been changed to also include courses without enrollments.