### PR TITLE
Deactivation flow QA follow up

### DIFF
--- a/src/features/offerings/EnrolledOfferingList.jsx
+++ b/src/features/offerings/EnrolledOfferingList.jsx
@@ -7,12 +7,12 @@ import { Spinner, Stack } from '@openedx/paragon';
 import PartnerName from '../partners/PartnerName';
 import EnrolledOfferingCard from './EnrolledOfferingCard';
 import useOfferings from './useOfferings';
-import { selectOfferingsByPartnerSlug } from './offeringsSlice';
+import { selectEnrolledOfferingsByPartnerSlug } from './offeringsSlice';
 
 export default function EnrolledOfferingList({ partnerSlug }) {
   const isEnrolled = true;
   const [partnerOfferings, offeringsStatus] = useOfferings(
-    (state) => selectOfferingsByPartnerSlug(state, partnerSlug, isEnrolled),
+    (state) => selectEnrolledOfferingsByPartnerSlug(state, partnerSlug, isEnrolled),
   );
   const uniqueOfferings = uniqBy(partnerOfferings, 'details.courseKey');
 

--- a/src/features/offerings/PartnerOfferingList.jsx
+++ b/src/features/offerings/PartnerOfferingList.jsx
@@ -7,11 +7,11 @@ import { CardGrid, Spinner } from '@openedx/paragon';
 import PartnerName from '../partners/PartnerName';
 import OfferingCard from './OfferingCard';
 import useOfferings from './useOfferings';
-import { selectEnrolledOfferingsByPartnerSlug } from './offeringsSlice';
+import { selectOfferingsByPartnerSlug } from './offeringsSlice';
 
 export default function PartnerOfferingList({ partnerSlug }) {
   const [partnerOfferings, offeringsStatus] = useOfferings(
-    (state) => selectEnrolledOfferingsByPartnerSlug(state, partnerSlug),
+    (state) => selectOfferingsByPartnerSlug(state, partnerSlug),
   );
   const uniqueOfferings = uniqBy(partnerOfferings, 'details.courseKey');
 


### PR DESCRIPTION
Previously, we were incorrectly listing enrolled and available courses for a user, which was also partly responsible for the deactivation flow appearing to be broken. This PR swaps the selectors used on the respective components.