### PR TITLE
Update cohort membership import flow to accommodate background task

### DIFF
--- a/src/features/cohorts/CohortDetail.jsx
+++ b/src/features/cohorts/CohortDetail.jsx
@@ -31,8 +31,8 @@ export default function CohortDetails() {
     return <Spinner animation="border" className="mie-3" screenReaderText="loading" />;
   }
 
-  const importCallback = (results) => {
-    setImportResults(results);
+  const importCallback = (taskStarted) => {
+    setImportResults(taskStarted);
     closeImportMembers();
   };
 
@@ -41,7 +41,7 @@ export default function CohortDetails() {
   return (
     <>
       {importResults && (
-        <Alert variant="success" show dismissible onClose={clearResults}>You successfully imported {importResults} learners.</Alert>
+        <Alert variant="success" show dismissible onClose={clearResults}>A background task has been initiated to import members. Please check back later.</Alert>
       )}
       <PartnerHeading partnerName={partner?.name}>
         <Button variant="inverse-outline-primary" href={`/${partnerSlug}/details`}>View</Button>

--- a/src/features/members/ImportMembersModal.jsx
+++ b/src/features/members/ImportMembersModal.jsx
@@ -15,11 +15,11 @@ export default function ImportMembersModal({ isOpen, onClose, cohort }) {
   const [filename, setFilename] = useState('');
   const [errorMessage, setError] = useState('');
 
-  const handleOnClose = (numMembersImported) => {
+  const handleOnClose = (taskStarted) => {
     setError('');
     setFilename('');
     setEmailList([]);
-    onClose(numMembersImported);
+    onClose(taskStarted);
   };
 
   const onDrop = useCallback((acceptedFiles) => {
@@ -44,23 +44,15 @@ export default function ImportMembersModal({ isOpen, onClose, cohort }) {
 
   const onImportMembersClicked = async () => {
     setError('');
-    let numMembersImported = 0;
+    let taskStarted = false;
     try {
       const response = await dispatch(importMembers({ cohort, emailList }));
-      const newMembers = response.payload?.members;
-
-      numMembersImported = Object.keys(newMembers).map(
-        memberId => newMembers[memberId],
-      ).length;
-      const expectedNumMembers = emailList.length;
-      if (numMembersImported !== expectedNumMembers) {
-        return setError(`The uploaded list contained duplicates or invalid emails. Added ${numMembersImported} out of ${expectedNumMembers} expected members.`);
-      }
+      taskStarted = [200, 201].includes(response.payload.status);
     } catch (err) {
       console.error(err);
-      return setError('There was an error reading the uploaded file. Please verify and try again.');
+      return setError('There was an error importing the list of members. Please verify and try again.');
     }
-    return handleOnClose(numMembersImported);
+    return handleOnClose(taskStarted);
   };
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });

--- a/src/features/members/membersSlice.js
+++ b/src/features/members/membersSlice.js
@@ -4,7 +4,6 @@ import {
 import {
   camelCaseObject, snakeCaseObject,
 } from '@edx/frontend-platform';
-import { noralizeSliceData } from '../../utils/normalize';
 import { setupRequest } from '../../utils/requests';
 
 const membersAdapter = createEntityAdapter({
@@ -59,12 +58,11 @@ export const importMembers = createAsyncThunk(
   async (args) => {
     const { cohort, emailList } = args;
     const { client, baseUrl } = setupRequest();
-    const { data } = await client.post(
+    const response = await client.post(
       `${baseUrl}/api/partnerships/v0/memberships/${cohort}/`,
       snakeCaseObject(emailList.map(email => ({ email }))),
     );
-    const normalized = noralizeSliceData(camelCaseObject(data), 'members');
-    return normalized.entities;
+    return response;
   },
 );
 
@@ -107,9 +105,8 @@ const membersSlice = createSlice({
         state.status = 'loading';
         state.currentRequestId = action.meta.requestId;
       })
-      .addCase(importMembers.fulfilled, (state, action) => {
+      .addCase(importMembers.fulfilled, (state) => {
         state.status = 'success';
-        membersAdapter.upsertMany(state, action.payload.members);
       })
       .addCase(importMembers.rejected, (state, action) => {
         state.status = 'failed';

--- a/src/utils/normalize.js
+++ b/src/utils/normalize.js
@@ -1,9 +1,0 @@
-// eslint-disable-next-line
-export const noralizeSliceData = (data, key) => {
-  const normalizedData = { entities: { [key]: {} }, result: [] };
-  return data.reduce((_, item) => {
-    normalizedData.entities[key][item.id] = item;
-    normalizedData.result.push(item.id);
-    return normalizedData;
-  }, {});
-};


### PR DESCRIPTION
### Fixes https://trello.com/c/wlqLlotm/619-partners-cohort-details-member-import-should-be-a-background-task

Updates the cohort membership import flow for https://github.com/academic-innovation/mogc-partnerships/pull/44. Replaces list error checking and updates banner to inform user to check back later for results.

In the future, we should have some sort of polling system for more detailed and user-friendly import processes.