### PR TITLE
Swap react-dropzone for paragon dropzone (617)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "prop-types": "15.8.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "react-dropzone": "^14.2.3",
         "react-helmet": "^6.1.0",
         "react-redux": "8.1.3",
         "react-router": "6.22.3",
@@ -35,7 +34,7 @@
         "regenerator-runtime": "0.14.1"
       },
       "devDependencies": {
-        "@edx/frontend-build": "^13.0.10",
+        "@edx/frontend-build": "13.0.10",
         "codecov": "3.8.3",
         "es-check": "7.1.1",
         "glob": "10.3.10",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "prop-types": "15.8.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
-    "react-dropzone": "^14.2.3",
     "react-helmet": "^6.1.0",
     "react-redux": "8.1.3",
     "react-router": "6.22.3",

--- a/src/features/cohorts/CohortDetail.jsx
+++ b/src/features/cohorts/CohortDetail.jsx
@@ -38,7 +38,7 @@ export default function CohortDetails() {
 
   return (
     <>
-      {importResults && (
+      {importResults !== null && (
         <Alert variant="success" show dismissible onClose={clearResults}>You successfully imported {importResults} learners.</Alert>
       )}
       <PartnerHeader selectedView="cohortDetail" activeLabel={cohort?.name} />

--- a/src/features/members/membersSlice.js
+++ b/src/features/members/membersSlice.js
@@ -4,7 +4,7 @@ import {
 import {
   camelCaseObject, snakeCaseObject,
 } from '@edx/frontend-platform';
-import { noralizeSliceData } from '../../utils/normalize';
+import noralizeSliceData from '../../utils/normalize';
 import { setupRequest } from '../../utils/requests';
 
 const membersAdapter = createEntityAdapter({

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -9,3 +9,5 @@ export const COHORT_MEMBERSHIP_STATUS_TYPE_MAP = {
   1: 'Activated',
   2: 'Deactivated',
 };
+
+export const MEBIBYTE = 2 ** 20;

--- a/src/utils/normalize.js
+++ b/src/utils/normalize.js
@@ -1,9 +1,10 @@
-// eslint-disable-next-line
-export const noralizeSliceData = (data, key) => {
-  const normalizedData = { entities: { [key]: {} }, result: [] };
-  return data.reduce((_, item) => {
-    normalizedData.entities[key][item.id] = item;
-    normalizedData.result.push(item.id);
-    return normalizedData;
-  }, {});
+const noralizeSliceData = (data, key) => {
+  const entities = {};
+  data.forEach((item) => { entities[item.id] = item; });
+  return {
+    entities: { [key]: entities },
+    result: Object.keys(entities),
+  };
 };
+
+export default noralizeSliceData;


### PR DESCRIPTION
# Overview
- Swaps out react drop zone for the native paragon drop zone. 
- Allows uploading of empty files, but warns the user that the file is empty.
- Fixes bug in normalization where an empty input array returns an empty object (unexpected shape).
- Memoizes template generation so the template is not re-generated on every render.
- Restrict file selection of “.csv” files of 1 mebibyte of less.

## Before
|Initial|File selected|Empty file selected|
|------|------------|-------------------|
|<img width="519" alt="Screenshot 2024-11-12 at 9 53 17 AM" src="https://github.com/user-attachments/assets/9bd4b204-c5b7-42fd-9060-37bbf6527e95">|<img width="515" alt="Screenshot 2024-11-12 at 9 53 37 AM" src="https://github.com/user-attachments/assets/c48f8a70-9f92-4157-9409-5d03e2d3cb61">|<img width="519" alt="Screenshot 2024-11-12 at 9 53 17 AM" src="https://github.com/user-attachments/assets/9bd4b204-c5b7-42fd-9060-37bbf6527e95">|

## After
|Initial|File selected|Empty file selected|
|------|------------|-------------------|
|<img width="513" alt="Screenshot 2024-11-11 at 4 07 09 PM" src="https://github.com/user-attachments/assets/3c3828d9-3bb7-454f-a10c-1d430b4a18b5">|<img width="515" alt="Screenshot 2024-11-12 at 10 31 26 AM" src="https://github.com/user-attachments/assets/10a56344-1cde-44b5-a4b2-fad7f3b587db">|<img width="517" alt="Screenshot 2024-11-12 at 10 22 48 AM" src="https://github.com/user-attachments/assets/fcea277c-a7f7-4c68-9df1-ad4d48d69f27">|