### PR TITLE
Fix ImportMembersModal corner cases (617)

### DIFF
--- a/src/features/cohorts/CohortDetail.jsx
+++ b/src/features/cohorts/CohortDetail.jsx
@@ -29,11 +29,6 @@ export default function CohortDetails() {
     return <Spinner animation="border" className="mie-3" screenReaderText="loading" />;
   }
 
-  const importCallback = (results) => {
-    setImportResults(results);
-    closeImportMembers();
-  };
-
   const clearResults = () => setImportResults(null);
 
   return (
@@ -85,7 +80,8 @@ export default function CohortDetails() {
 
       <ImportMembersModal
         isOpen={isImportMembersOpen}
-        onClose={importCallback}
+        closeModal={closeImportMembers}
+        onMembersImported={setImportResults}
         cohort={cohort.uuid}
       />
     </>


### PR DESCRIPTION
- Split close modal and set imported member data functions so false import success banners are not displayed on modal close.
- Simplify upload error handling by removing unreachable case (duplicates are returned by the server just like new members).
- Clear file state on error so the user cannot immediately click import again.
- Disable import button if no file is selected.