### PR TITLE
636 partner detail UI tweaks

### DIFF
--- a/src/common/index.scss
+++ b/src/common/index.scss
@@ -21,3 +21,8 @@
     border-color: $light-100;
   }
 }
+
+.gap-1 { gap: .25rem; }
+.gap-2 { gap: .5rem; }
+.gap-3 { gap: .75rem; }
+.gap-4 { gap: 1rem; }

--- a/src/features/partners/PartnerHeader/ManagementToolbar.jsx
+++ b/src/features/partners/PartnerHeader/ManagementToolbar.jsx
@@ -1,29 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { NavLink } from 'react-router-dom';
 import ButtonLink from '../../../common/ButtonLink';
 import ButtonLinkGroup from '../../../common/ButtonLinkGroup';
 
 import { useRouteContext } from '../../../common/RouteContext';
 
-export default function ManagementToolbar({ partner, selected, showPreview }) {
+const navButtonStyle = ({ isActive }) => `btn ${isActive ? 'btn-dark' : 'btn-outline-dark'}`;
+
+export default function ManagementToolbar({ partner, showPreview }) {
   const { sharedState, setSharedState } = useRouteContext();
 
   const togglePreview = () => setSharedState({ isPreview: !sharedState.isPreview });
 
-  const options = ['insights', 'cohorts'];
-  const selectedOpt = selected === null ? false : options[Number(selected)];
-  const cohortClass = `btn btn-${selectedOpt === options[1] ? 'dark' : 'outline-dark'}`;
-  const insightClass = `btn btn-${selectedOpt === options[0] ? 'dark' : 'outline-dark'}`;
   return (
     <div className="row">
       <div className="col d-flex flex-column flex-sm-row justify-content-between gap-4">
         <ButtonLinkGroup>
-          <ButtonLink className={cohortClass} link={`/${partner}/admin`}>
+          <NavLink className={navButtonStyle} to={`/${partner}/admin`} end>
             Cohorts
-          </ButtonLink>
-          <ButtonLink className={insightClass} link={`/${partner}/admin/insights`}>
+          </NavLink>
+          <NavLink className={navButtonStyle} to={`/${partner}/admin/insights`}>
             Insights
-          </ButtonLink>
+          </NavLink>
         </ButtonLinkGroup>
 
         {showPreview && (
@@ -37,12 +36,10 @@ export default function ManagementToolbar({ partner, selected, showPreview }) {
 }
 
 ManagementToolbar.defaultProps = {
-  selected: null,
   showPreview: false,
 };
 
 ManagementToolbar.propTypes = {
   partner: PropTypes.string.isRequired,
-  selected: PropTypes.bool,
   showPreview: PropTypes.bool,
 };

--- a/src/features/partners/PartnerHeader/ManagementToolbar.jsx
+++ b/src/features/partners/PartnerHeader/ManagementToolbar.jsx
@@ -16,7 +16,7 @@ export default function ManagementToolbar({ partner, selected, showPreview }) {
   const insightClass = `btn btn-${selectedOpt === options[0] ? 'dark' : 'outline-dark'}`;
   return (
     <div className="row">
-      <div className="col col-9">
+      <div className="col d-flex flex-column flex-sm-row justify-content-between gap-4">
         <ButtonLinkGroup>
           <ButtonLink className={cohortClass} link={`/${partner}/admin`}>
             Cohorts
@@ -25,14 +25,13 @@ export default function ManagementToolbar({ partner, selected, showPreview }) {
             Insights
           </ButtonLink>
         </ButtonLinkGroup>
+
+        {showPreview && (
+        <ButtonLink className="btn btn-primary" link={`/${partner}/details`} onClick={togglePreview}>
+          Preview As Learner
+        </ButtonLink>
+        )}
       </div>
-      {showPreview && (
-        <div className="col col-3">
-          <ButtonLink className="btn btn-primary" link={`/${partner}/details`} onClick={togglePreview}>
-            Preview As Learner
-          </ButtonLink>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/features/partners/PartnerHeader/PartnerHeader.jsx
+++ b/src/features/partners/PartnerHeader/PartnerHeader.jsx
@@ -76,16 +76,17 @@ export default function PartnerHeader({ selectedView, activeLabel }) {
 
       <section className="p-3">
         <Container size="lg">
+          <ResponsiveBreadcrumb
+            links={viewSettings.breadcrumbLinks}
+            activeLabel={activeLabel}
+          />
+
           {(partner?.isManager && !isPreview) && (
             <ManagementToolbar
               partner={partnerSlug}
               showPreview={viewSettings.showPreview}
             />
           )}
-          <ResponsiveBreadcrumb
-            links={viewSettings.breadcrumbLinks}
-            activeLabel={activeLabel}
-          />
         </Container>
       </section>
     </>


### PR DESCRIPTION
- Move breadcrumbs above the page content.
- Fixed button alignment and layout as a column on narrow screens.
- Fix broken page selector button group. The style overrides for theme color dark buttons do not seem to exist, so they will have to be overridden in a different change. For now, buttons are still green.

Breadcrumbs:
Before:
<img width="1523" alt="bc_before" src="https://github.com/user-attachments/assets/4e621c5a-7a84-442a-8455-91ba3c84fe96">
After:
<img width="1524" alt="bc_after" src="https://github.com/user-attachments/assets/7638029f-8b6f-48f2-9780-2b0e47a96f84">

Buttons mobile:
| Before | After |
|--------|-----|
|<img width="390" alt="buttons_before_mob" src="https://github.com/user-attachments/assets/2bd50075-8c91-4731-a4c9-ff006d8bc0c0">|<img width="391" alt="buttons_after_mob" src="https://github.com/user-attachments/assets/3c576a52-34d3-4b90-9c20-8547a0fdadbb">|

Buttons desktop after:
<img width="1397" alt="buttons_desktop_after" src="https://github.com/user-attachments/assets/8a1ca321-c77d-44f7-8f11-89c3d9f661b2">
